### PR TITLE
Don't prefix branch name

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,9 +39,7 @@ func (c *Client) QueueBuild(buildTypeID string, branchName string, properties ma
 		BranchName string `json:"branchName,omitempty"`
 	}{}
 	jsonQuery.BuildTypeID = buildTypeID
-	if branchName != "" {
-		jsonQuery.BranchName = fmt.Sprintf("refs/heads/%s", branchName)
-	}
+	jsonQuery.BranchName = branchName
 	for k, v := range properties {
 		jsonQuery.Properties.Property = append(jsonQuery.Properties.Property, oneProperty{k, v})
 	}


### PR DESCRIPTION
If the `branchName` contains full branch name then it doesn't work because you end with `refs/heads/refs/heads/MyBranch`